### PR TITLE
ENH: Allow nan values in JSON output (violating JSON std but useful)

### DIFF
--- a/questplus/qp.py
+++ b/questplus/qp.py
@@ -313,7 +313,7 @@ class QuestPlus:
         self_copy.prior = self_copy.prior.to_dict()
         self_copy.posterior = self_copy.posterior.to_dict()
         self_copy.likelihoods = self_copy.likelihoods.to_dict()
-        return json_tricks.dumps(self_copy)
+        return json_tricks.dumps(self_copy, allow_nan=True)
 
     @staticmethod
     def from_json(data: str):


### PR DESCRIPTION
Calculating the logarithm of (near-)zero values generates nan's. We want to preserve those in the JSON output, even though this means a violation of the JSON standard.