### PR TITLE
BF: should be gamma (lower asymptote) rather than delta (lapse rate)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+development
+-----------
+* Fix definition of `norm_cdf` psychometric function, by [Alex Forrence](https://github.com/aforren1)
+
 v2019.4
 -------
 * Allow JSON serialization of random number generator

--- a/questplus/psychometric_function.py
+++ b/questplus/psychometric_function.py
@@ -256,7 +256,7 @@ def norm_cdf(*,
 
     def _mu_func(x, mu, sd_, gamma, delta):
         norm = scipy.stats.norm(loc=mu, scale=sd_)
-        return delta + (1 - gamma - delta) * norm.cdf(x)
+        return gamma + (1 - gamma - delta) * norm.cdf(x)
 
     p = xr.apply_ufunc(_mu_func, x, mu, sd_, gamma, delta)
     return p


### PR DESCRIPTION
Thanks for providing this package! I was doing some simulations and noticed this typo. Example:

```python
import numpy as np
import scipy.stats
import matplotlib.pyplot as plt

def old_ver(x, mu, sd_, gamma, delta):
    norm = scipy.stats.norm(loc=mu, scale=sd_)
    return delta + (1 - gamma - delta) * norm.cdf(x)

def new_ver(x, mu, sd_, gamma, delta):
    norm = scipy.stats.norm(loc=mu, scale=sd_)
    return gamma + (1 - gamma - delta) * norm.cdf(x)

x = np.linspace(0, 0.5, 100)
# mean=0.25, sd=0.01, lower_asymptote(gamma)=0.5, lapse_rate(delta)=0
pars = {'mu': 0.25, 'sd_': 0.01, 'gamma': 0.5, 'delta': 0}
y_old = old_ver(x, **pars)
y_new = new_ver(x, **pars)

plt.plot(x, y_old, label='old')
plt.plot(x, y_new, label='new')
plt.legend()
plt.xlim(0, 0.5)
plt.ylim(-0.01, 1.01)
plt.show()
```

![fig](https://user-images.githubusercontent.com/4573394/85033682-38b2dc00-b14f-11ea-9333-47c4258c4737.png)